### PR TITLE
[DPE-6902] Add shm plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,6 +14,10 @@ architectures:
 grade: stable
 confinement: strict
 
+plugs:
+  shared-memory:
+    private: true
+
 system-usernames:
   snap_daemon: shared
 


### PR DESCRIPTION
Need to enable the private plug to use private /dev/shm inside the snap.