### PR TITLE
[MISC] Concurency conflict

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @canonical/data-postgresql

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,10 +2,6 @@
 # See LICENSE file for licensing details.
 name: Release to Snap Store
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   push:
     branches:


### PR DESCRIPTION
Port of https://github.com/canonical/charmed-postgresql-snap/pull/240 for PGB snap.

Removing concurrency group from release.

